### PR TITLE
Add license to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Add the license to the `MANIFEST.in` to ensure it is included in packages like `sdist`s.
