### PR TITLE
Support astroid 2

### DIFF
--- a/pylint_common/augmentations.py
+++ b/pylint_common/augmentations.py
@@ -1,4 +1,6 @@
-from pylint.checkers.base import BasicChecker, astroid
+import astroid
+from astroid.__pkginfo__ import numversion as ASTROID_VERSION
+from pylint.checkers.base import BasicChecker
 from pylint_plugin_utils import augment_visit
 
 
@@ -7,6 +9,11 @@ try:
     BASESTRING = basestring
 except NameError:
     BASESTRING = str
+
+if ASTROID_VERSION >= (2, 0):
+    AstroidClass = astroid.ClassDef
+else:
+    AstroidClass = astroid.Class
 
 
 def allow_attribute_comments(chain, node):
@@ -20,7 +27,7 @@ def allow_attribute_comments(chain, node):
 
     # TODO: find the relevant citation for why this is the correct way to comment attributes
     if isinstance(node.previous_sibling(), astroid.Assign) and \
-            isinstance(node.parent, (astroid.Class, astroid.Module)) and \
+            isinstance(node.parent, (AstroidClass, astroid.Module)) and \
             isinstance(node.value, astroid.Const) and \
             isinstance(node.value.value, BASESTRING):
         return

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import sys
 from setuptools import find_packages, setup
 
@@ -30,6 +30,12 @@ if sys.version_info < (2, 7):
         'pylint>=1.0,<1.4',
         'astroid>=1.0,<1.3.0',
         'logilab-common>=0.60.0,<0.63',
+        'pylint-plugin-utils>=0.2.6',
+    ]
+elif sys.version_info < (3, 0):
+    _install_requires = [
+        'pylint>=1.0,<2.0',
+        'astroid<2.0',
         'pylint-plugin-utils>=0.2.6',
     ]
 else:


### PR DESCRIPTION
Resolves #9.

`astroid` changed the class scope node name starting on version 2, `pylint-common` should be able to use it to be compatible with `python` >= 2. It also enables prospector to properly use `pylint` 2.